### PR TITLE
Add validation against current highest bid

### DIFF
--- a/routes/bids.js
+++ b/routes/bids.js
@@ -36,6 +36,14 @@ router.post('/', (req, res) => {
             .json({ message: 'Bid amount must be a number greater than 0' });
     }
 
+    const currentHighest = bidsService.getHighestBidAmountForAuction(auctionId);
+
+    if (currentHighest !== null && parsedAmount <= currentHighest) {
+        return res.status(400).json({
+            message: `Bid amount must be greater than current highest bid (${currentHighest})`,
+        });
+    }
+
     const bid = bidsService.createBid({ auctionId, userId, amount: parsedAmount });
 
     res.json({

--- a/services/bidsService.js
+++ b/services/bidsService.js
@@ -24,9 +24,23 @@ function getBidById(id) {
     return bids.find((b) => String(b.id) === String(id));
 }
 
+function getHighestBidAmountForAuction(auctionId) {
+    const auctionBids = bids.filter((bid) => String(bid.auctionId) === String(auctionId));
+
+    if (!auctionBids.length) {
+        return null;
+    }
+
+    return auctionBids.reduce(
+        (max, bid) => (bid.amount > max ? bid.amount : max),
+        auctionBids[0].amount,
+    );
+}
+
 module.exports = {
     createBid,
     getBids,
     getBidById,
+    getHighestBidAmountForAuction,
 };
 

--- a/tests/bids.test.js
+++ b/tests/bids.test.js
@@ -23,5 +23,29 @@ describe('Bids endpoints', () => {
     expect(listRes.body.length).toBeGreaterThan(0);
     expect(listRes.body[0]).toMatchObject({ auctionId, userId, amount: 100 });
   });
+
+  it('should reject bids that are not higher than current highest bid', async () => {
+    const userId = 'user-2';
+    const auctionId = 'auction-2';
+
+    // First, place an initial bid
+    const firstBidRes = await request(app).post('/api/bids').send({
+      auctionId,
+      userId,
+      amount: 150,
+    });
+
+    expect(firstBidRes.status).toBe(200);
+
+    // Try to place a lower or equal bid
+    const lowerBidRes = await request(app).post('/api/bids').send({
+      auctionId,
+      userId,
+      amount: 150,
+    });
+
+    expect(lowerBidRes.status).toBe(400);
+    expect(lowerBidRes.body).toHaveProperty('message');
+  });
 });
 


### PR DESCRIPTION
This PR adds validation to ensure that new bids are always higher than the current maximum bid for a given auction.

### Changes
- **services/bidsService.js**
  - Added `getHighestBidAmountForAuction(auctionId)` to compute the highest bid amount for a given auction from the in-memory bids list.

- **routes/bids.js**
  - Updated `POST /api/bids` to:
    - Parse and validate the bid amount as before.
    - Look up the current highest bid for the given `auctionId` using `bidsService.getHighestBidAmountForAuction`.
    - Reject the request with HTTP 400 if the new bid amount is **not strictly greater** than the current highest bid, returning a clear error message.

- **tests/bids.test.js**
  - Extended the tests to cover the new validation behavior by asserting that a second bid with the same amount for the same auction is rejected with status 400.

This ensures that clients cannot place bids that are below or equal to the current maximum bid amount.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author